### PR TITLE
Custom binary sensor

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import (
     uart,
     sensor,
+    binary_sensor,
     switch,
     select,
     number,
@@ -36,7 +37,7 @@ from esphome import pins
 
 CODEOWNERS = ["matthias882", "lanwin", "omerfaruk-aran"]
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["sensor", "switch", "select", "number", "climate", "text_sensor"]
+AUTO_LOAD = ["sensor", "binary_sensor", "switch", "select", "number", "climate", "text_sensor"]
 MULTI_CONF = False
 
 CONF_SAMSUNG_AC_ID = "samsung_ac_id"
@@ -85,6 +86,7 @@ CONF_DEVICE_ROOM_HUMIDITY = "room_humidity"
 CONF_DEVICE_CUSTOM = "custom_sensor"
 CONF_DEVICE_CUSTOM_MESSAGE = "message"
 CONF_DEVICE_CUSTOM_RAW_FILTERS = "raw_filters"
+CONF_DEVICE_CUSTOM_TYPE = "type"
 CONF_DEVICE_ERROR_CODE = "error_code"
 CONF_DEVICE_OUT_CONTROL_WATTMETER_ALL_UNIT_ACCUM = "outdoor_instantaneous_power"
 CONF_DEVICE_OUT_CONTROL_WATTMETER_1W_1MIN_SUM = "outdoor_cumulative_energy"
@@ -151,12 +153,30 @@ CAPABILITIES_SCHEMA = cv.Schema(
     }
 )
 
-CUSTOM_SENSOR_SCHEMA = sensor.sensor_schema().extend(
+CUSTOM_NUMERIC_SENSOR_SCHEMA = sensor.sensor_schema().extend(
     {
         cv.Required(CONF_DEVICE_CUSTOM_MESSAGE): cv.hex_int,
+        cv.Optional(CONF_DEVICE_CUSTOM_TYPE, default="sensor"): cv.one_of(
+            "sensor",
+            lower=True,
+        ),
     }
 )
 
+CUSTOM_BINARY_SENSOR_SCHEMA = binary_sensor.binary_sensor_schema().extend(
+    {
+        cv.Required(CONF_DEVICE_CUSTOM_MESSAGE): cv.hex_int,
+        cv.Required(CONF_DEVICE_CUSTOM_TYPE): cv.one_of(
+            "binary",
+            lower=True,
+        ),
+    }
+)
+
+CUSTOM_SENSOR_SCHEMA = cv.Any(
+    CUSTOM_NUMERIC_SENSOR_SCHEMA,
+    CUSTOM_BINARY_SENSOR_SCHEMA,
+)
 
 def custom_sensor_schema(
     message: int,
@@ -584,12 +604,22 @@ async def to_code(config):
 
         if CONF_DEVICE_CUSTOM in device:
             for cust_sens in device[CONF_DEVICE_CUSTOM]:
-                sens = await sensor.new_sensor(cust_sens)
-                cg.add(
-                    var_dev.add_custom_sensor(
-                        cust_sens[CONF_DEVICE_CUSTOM_MESSAGE], sens
+                custom_type = cust_sens.get(CONF_DEVICE_CUSTOM_TYPE, "sensor")
+
+                if custom_type == "binary":
+                    sens = await binary_sensor.new_binary_sensor(cust_sens)
+                    cg.add(
+                        var_dev.add_custom_binary_sensor(
+                            cust_sens[CONF_DEVICE_CUSTOM_MESSAGE], sens
+                        )
                     )
-                )
+                else:
+                    sens = await sensor.new_sensor(cust_sens)
+                    cg.add(
+                        var_dev.add_custom_sensor(
+                            cust_sens[CONF_DEVICE_CUSTOM_MESSAGE], sens
+                        )
+                    )
 
         for key in CUSTOM_SENSOR_KEYS:
             if key in device:

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -6,6 +6,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/select/select.h"
 #include "esphome/components/number/number.h"
@@ -140,6 +141,7 @@ namespace esphome
       Samsung_AC_Water_Heater_Mode_Select *waterheatermode{nullptr};
       Samsung_AC_Climate *climate{nullptr};
       std::map<uint16_t, sensor::Sensor *> custom_sensor_map;
+      std::map<uint16_t, binary_sensor::BinarySensor *> custom_binary_sensor_map;
       float room_temperature_offset{0};
 
       template <typename SwingType>
@@ -210,6 +212,12 @@ namespace esphome
         {
           it->second->publish_state(value);
         }
+
+        auto binary_it = custom_binary_sensor_map.find(message_number);
+        if (binary_it != custom_binary_sensor_map.end())
+        {
+          binary_it->second->publish_state(value != 0);
+        }
       }
 
       void set_room_temperature_sensor(sensor::Sensor *sensor)
@@ -231,6 +239,11 @@ namespace esphome
       void add_custom_sensor(int message_number, sensor::Sensor *sensor)
       {
         custom_sensor_map[(uint16_t)message_number] = sensor;
+      }
+
+      void add_custom_binary_sensor(int message_number, binary_sensor::BinarySensor *sensor)
+      {
+        custom_binary_sensor_map[(uint16_t)message_number] = sensor;
       }
 
       void set_power_switch(Samsung_AC_Switch *switch_)

--- a/example.yaml
+++ b/example.yaml
@@ -113,7 +113,7 @@ samsung_ac:
       # Optional: show Samsung Auto as HA Heat/Cool (allows setting target temp in HA UI)
       map_auto_to_heat_cool: false
 
-      # Configures/overrides the capabilites for this devices. 
+      # Configures/overrides the capabilities for this device.      
       # Look above for all options.
       capabilities:
         horizontal_swing: false # This device have no h swing. 
@@ -154,6 +154,29 @@ samsung_ac:
       room_humidity:
         name: "Kitchen humidity"
       
+      # Only supported on NASA-based heat pumps
+      water_temperature:
+        name: "Warm water"
+      water_target_temperature:
+        name: "Hot Water Target Temperature"
+      water_heater_mode:
+        name: "Hotwater Mode"
+      
+      # Custom sensors can be used to expose additional Samsung bus messages.
+      # Use debug_log_messages or debug MQTT output to identify the message number you want.
+      # By default, custom_sensor creates a numeric sensor.
+      custom_sensor:
+        - name: "Kitchen custom value"
+          message: 0x1234
+
+        # Set type: binary to expose a bus message as a binary_sensor.
+        # Binary custom sensors are off when the decoded value is 0 and on for any non-zero value.
+        - name: "Kitchen custom binary flag"
+          message: 0x4087
+          type: binary
+          device_class: heat
+          entity_category: diagnostic
+      
     - address: "10.00.00" # Outdoor device address as the following components are dependent on an outdoor unit.
       # This sensor captures and monitors specific error codes returned by the HVAC system.
       # When an error occurs, the sensor detects the error code and updates its value accordingly.
@@ -189,14 +212,7 @@ samsung_ac:
       # Consistent voltage readings indicate stable power delivery, while deviations can help detect electrical issues in the system.
       outdoor_voltage:
         name: "Outdoor Voltage"
-
-      # Only supported on NASA based heatpumps
-      water_temperature:
-        name: "Warm water"
-      water_target_temperature:
-        name: "Hot Water Target Temperature"
-      water_heater_mode:
-        name: "Hotwater Mode"
+        
       outdoor_temperature: # Should be used with outdoor device address
         name: "Outdoor temperature"
 

--- a/example.yaml
+++ b/example.yaml
@@ -161,16 +161,18 @@ samsung_ac:
         name: "Hot Water Target Temperature"
       water_heater_mode:
         name: "Hotwater Mode"
-      
+          
       # Custom sensors can be used to expose additional Samsung bus messages.
-      # Use debug_log_messages or debug MQTT output to identify the message number you want.
+      # Use debug_log_messages or debug MQTT output to discover the message number for your device.
+      # The message numbers below are examples only and should be replaced with values from your own bus.
       # By default, custom_sensor creates a numeric sensor.
       custom_sensor:
         - name: "Kitchen custom value"
           message: 0x1234
 
         # Set type: binary to expose a bus message as a binary_sensor.
-        # Binary custom sensors are off when the decoded value is 0 and on for any non-zero value.
+        # Binary custom sensors publish false when the decoded value is 0,
+        # and true when the decoded value is any non-zero value.
         - name: "Kitchen custom binary flag"
           message: 0x4087
           type: binary


### PR DESCRIPTION
I've created this to compliment the custom sensors, so we can have binary sensors for some of the heat pump variables.

Needs a bit of a review, its generally fine I think apart from how I am handling the call to process the message, currently with an type (int) variable. If we think that's a good way of doing it, could firm that up with an enum, but interested on if there is a view of a better way?