### PR TITLE
[NonNasa] Prevent flooding the outdoor unit by registration requests

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -17,7 +17,11 @@ namespace esphome
     {
         std::list<NonNasaRequestQueueItem> nonnasa_requests;
         bool controller_registered = false;
+	bool controller_register_allow = false;
         bool indoor_unit_awake = true;
+
+	uint32_t start_millis = millis();
+	uint32_t registration_interval = 2000;
 
         uint8_t build_checksum(std::vector<uint8_t> &data)
         {
@@ -648,14 +652,22 @@ namespace esphome
         {
             // If we're not currently registered, keep sending a registration request until it has
             // been confirmed by the outdoor unit.
+            const uint32_t now = millis();
             if (!controller_registered)
             {
-                send_register_controller(target);
+                // Prevent registration flooding and send the registration request in a reasonable interval
+		if (now - start_millis >= registration_interval) {
+		    controller_register_allow = true;
+		}
+		if (controller_register_allow) {
+		    send_register_controller(target);
+		    controller_register_allow = false;
+		    start_millis = millis();
+		}
             }
 
             // If we have *any* messages in the queue for longer than 15s, assume failure and
             // remove from queue (the AC or UART connection is likely offline).
-            const uint32_t now = millis();
             nonnasa_requests.remove_if([&](const NonNasaRequestQueueItem &item)
                                        { return now - item.time > 15000; });
 


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [x] 🐞 Bug Fix
- [ ] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
1. .Adds control of registration requests towards outdoor unit at startup. Instead of flooding several times a minute it sends now just one every two seconds.


## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: #191 
---


## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2024.10.4
- **Home Assistant Version**: 2024.10.2

### 🧩 Devices
- **Air Conditioner Type**:
  - [ ] NASA
  - [X] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: AR09RXWXCWKX
- **Outdoor Unit Model**: AJ040NCJ2EG
- **ESP Device Model**: M5STACK ATOM Lite + M5STACK RS-485
- **Wiring Configuration**: F1/F2

---

