### PR TITLE
Optional Turbo Mode

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -85,6 +85,7 @@ CONF_DEVICE_OUT_SENSOR_VOLTAGE = "outdoor_voltage"
 CONF_CAPABILITIES = "capabilities"
 CONF_CAPABILITIES_HORIZONTAL_SWING = "horizontal_swing"
 CONF_CAPABILITIES_VERTICAL_SWING = "vertical_swing"
+CONF_CAPABILITIES_TURBO_MODE = "turbo_mode"
 
 CONF_PRESETS = "presets"
 CONF_PRESET_NAME = "name"
@@ -121,6 +122,7 @@ CAPABILITIES_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_CAPABILITIES_HORIZONTAL_SWING, default=False): cv.boolean,
         cv.Optional(CONF_CAPABILITIES_VERTICAL_SWING, default=False): cv.boolean,
+        cv.Optional(CONF_CAPABILITIES_TURBO_MODE, default=False): cv.boolean,
         cv.Optional(CONF_PRESETS): cv.Schema(
             dict(
                 [
@@ -367,6 +369,13 @@ async def to_code(config):
             cg.add(
                 var_dev.set_supports_horizontal_swing(
                     capabilities[CONF_CAPABILITIES_HORIZONTAL_SWING]
+                )
+            )
+
+        if CONF_CAPABILITIES_TURBO_MODE in capabilities:
+            cg.add(
+                var_dev.set_supports_turbo_mode(
+                    capabilities[CONF_CAPABILITIES_TURBO_MODE]
                 )
             )
 

--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -46,9 +46,13 @@ namespace esphome
 
       traits.set_supported_fan_modes(fan);
 
-      std::set<std::string> customFan;
-      customFan.insert("Turbo");
-      traits.set_supported_custom_fan_modes(customFan);
+      bool t = device->supports_turbo_mode();
+      if (t)
+      {
+        std::set<std::string> customFan;
+        customFan.insert("Turbo");
+        traits.set_supported_custom_fan_modes(customFan);
+      }
 
       auto supported = device->get_supported_alt_modes();
       if (!supported->empty())

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -459,6 +459,11 @@ namespace esphome
         return supports_vertical_swing_;
       }
 
+      bool supports_turbo_mode()
+      {
+        return supports_turbo_mode_;
+      }
+
       void set_supports_horizontal_swing(bool value)
       {
         supports_horizontal_swing_ = value;
@@ -467,6 +472,11 @@ namespace esphome
       void set_supports_vertical_swing(bool value)
       {
         supports_vertical_swing_ = value;
+      }
+
+      void set_supports_turbo_mode(bool value)
+      {
+        supports_turbo_mode_ = value;
       }
 
       void add_alt_mode(const AltModeName &name, AltMode value)
@@ -498,6 +508,7 @@ namespace esphome
     protected:
       bool supports_horizontal_swing_{false};
       bool supports_vertical_swing_{false};
+      bool supports_turbo_mode_{false};
       std::vector<AltModeDesc> alt_modes;
 
       Protocol *protocol{nullptr};

--- a/example.yaml
+++ b/example.yaml
@@ -68,6 +68,7 @@ samsung_ac:
   capabilities: 
     vertical_swing: true
     horizontal_swing: true
+    turbo_mode: true
     # Presets define special AC modes like Windfree, Eco, and so on. 
     # The following modes are available: sleep, quiet, fast, longreach, windfree, eco.
     presets: 


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
- [ ] 🐞 Bug Fix
- [x] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
1. Added a new configuration option to enable turbo mode.
2. Modified the component behavior to activate turbo mode when required.
3. Included validation to check whether turbo mode is enabled or not.

## 🔗 Related Issues
<!-- Si esta PR soluciona o está relacionada con algún problema, menciónalo aquí. -->
Fixes: https://github.com/omerfaruk-aran/esphome_samsung_hvac_bus/issues/226
Related: 

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2024.10.4
- **Home Assistant Version**: 2024.10.2

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: AC052RNMDKG
- **Outdoor Unit Model**: AC052RXADKG
- **ESP Device Model**: M5STACK ATOM Lite + M5STACK RS-485
- **Wiring Configuration**: F1/F2

---

## 🧪 **Test Plan**
### How were these changes tested?
- **Device used**: Tested on an air conditioner device model AC052RNMDKG with an ESP32.
- **Test cases**:
  1. Verify that turbo mode can be turned on/off correctly from the user interface.
  2. Test the device's response when turbo mode is enabled.

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->

---

## 🛠️ **YAML Configuration**
```yaml
# Please provide the relevant YAML configuration you used for testing this PR
```
