### PR TITLE
Replaced 'Middle' with 'Medium'

### DIFF
--- a/components/samsung_ac/conversions.cpp
+++ b/components/samsung_ac/conversions.cpp
@@ -113,7 +113,7 @@ namespace esphome
       case FanMode::Low:
         return climate::ClimateFanMode::CLIMATE_FAN_LOW;
       case FanMode::Mid:
-        return climate::ClimateFanMode::CLIMATE_FAN_MIDDLE;
+        return climate::ClimateFanMode::CLIMATE_FAN_MEDIUM;
       case FanMode::High:
         return climate::ClimateFanMode::CLIMATE_FAN_HIGH;
       case FanMode::Turbo:
@@ -141,7 +141,7 @@ namespace esphome
       {
       case climate::ClimateFanMode::CLIMATE_FAN_LOW:
         return FanMode::Low;
-      case climate::ClimateFanMode::CLIMATE_FAN_MIDDLE:
+      case climate::ClimateFanMode::CLIMATE_FAN_MEDIUM:
         return FanMode::Mid;
       case climate::ClimateFanMode::CLIMATE_FAN_HIGH:
         return FanMode::High;

--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -31,7 +31,7 @@ namespace esphome
 
       std::set<climate::ClimateFanMode> fan = {
           climate::ClimateFanMode::CLIMATE_FAN_HIGH,
-          climate::ClimateFanMode::CLIMATE_FAN_MIDDLE,
+          climate::ClimateFanMode::CLIMATE_FAN_MEDIUM,
           climate::ClimateFanMode::CLIMATE_FAN_LOW};
 
       if (this->mode != climate::CLIMATE_MODE_FAN_ONLY)


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [ ] 🐞 Bug Fix
- [ ] ✨ New Feature
- [x] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
1. Replaced 'Middle' with 'Medium' to ensure that the fan modes appear in the correct order."

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: 
Related: https://github.com/esphome/issues/issues/5860

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2024.10.4
- **Home Assistant Version**: 2024.10.2

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: AC052RNMDKG
- **Outdoor Unit Model**: AC052RXADKG
- **ESP Device Model**: M5STACK ATOM Lite + M5STACK RS-485
- **Wiring Configuration**: F1/F2

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. It is confirmed that it appears in the correct order
2. The modes work correctly