### PR TITLE
Fix Packet Acknowledgment & Retry Mechanism

### DIFF
--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -17,7 +17,6 @@ namespace esphome
             int retry_count;
             uint32_t last_sent_time;
 
-            // Add this operator==
             bool operator==(const PacketInfo& other) const {
                 return this->packet.command.packetNumber == other.packet.command.packetNumber;
             }


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [x] 🐞 Bug Fix
- [ ] ✨ New Feature
- [x] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
**This is a draft retry mechanism fix, on the way to implementing all the changes addressed in #93**
1. fix command resending when retrying.
2. Doubles the delay between each attempt, inorder to moderate the load (Exponential backoff).
3. Increases the number of retries to 8.
4. Portions are removed after maximum attempts.

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: #229
Related: #206

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2024.11.2
- **Home Assistant Version**: 2024.11.3

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: Global Mini4Way, 360CST, Fresh Out
- **Outdoor Unit Model**: (e.g., AJ050TXJ2KH/EA)
- **ESP Device Model**: WT32-ETH01 + Grove-RS485
- **Wiring Configuration**: F1/F2

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->


### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->

---

## 🛠️ **YAML Configuration**
```yaml
# Please provide the relevant YAML configuration you used for testing this PR
```
