### PR TITLE
Fix: Update MQTT client for ESP-IDF compatibility

### DIFF
--- a/.github/conf_esp_idf.yml
+++ b/.github/conf_esp_idf.yml
@@ -19,6 +19,11 @@ uart:
   parity: EVEN
 
 samsung_ac:
+  debug_mqtt_host: 192.168.1.100
+  debug_mqtt_port: 1883
+  debug_mqtt_username: mqtt_user
+  debug_mqtt_password: mqtt_pass
+
   debug_log_messages: false
   debug_log_messages_raw: false
 

--- a/.github/conf_esp_idf.yml
+++ b/.github/conf_esp_idf.yml
@@ -5,7 +5,6 @@ esp32:
   board: m5stack-atom
   framework:
     type: esp-idf
-    version: recommended
 
 external_components:
   - source:

--- a/.github/conf_esp_idf.yml
+++ b/.github/conf_esp_idf.yml
@@ -5,7 +5,7 @@ esp32:
   board: m5stack-atom
   framework:
     type: esp-idf
-    version: latest
+    version: v5.1.5
 
 external_components:
   - source:

--- a/.github/conf_esp_idf.yml
+++ b/.github/conf_esp_idf.yml
@@ -5,7 +5,7 @@ esp32:
   board: m5stack-atom
   framework:
     type: esp-idf
-    version: v5.1.5
+    version: latest
 
 external_components:
   - source:

--- a/.github/conf_esp_idf.yml
+++ b/.github/conf_esp_idf.yml
@@ -5,6 +5,7 @@ esp32:
   board: m5stack-atom
   framework:
     type: esp-idf
+    version: latest
 
 external_components:
   - source:

--- a/components/samsung_ac/debug_mqtt.cpp
+++ b/components/samsung_ac/debug_mqtt.cpp
@@ -45,14 +45,10 @@ namespace esphome
 #elif defined(USE_ESP32)
             if (mqtt_client == nullptr)
             {
+                std::string uri = "mqtt://" + (!username.empty() ? username + ":" + password + "@" : "") + host + ":" + std::to_string(port);
+
                 esp_mqtt_client_config_t mqtt_cfg = {};
-                mqtt_cfg.host = host.c_str();
-                mqtt_cfg.port = port;
-                if (!username.empty())
-                {
-                    mqtt_cfg.username = username.c_str();
-                    mqtt_cfg.password = password.c_str();
-                }
+                mqtt_cfg.uri = uri.c_str();
                 mqtt_client = esp_mqtt_client_init(&mqtt_cfg);
                 esp_mqtt_client_start(mqtt_client);
             }

--- a/components/samsung_ac/debug_mqtt.cpp
+++ b/components/samsung_ac/debug_mqtt.cpp
@@ -45,12 +45,19 @@ namespace esphome
 #elif defined(USE_ESP32)
             if (mqtt_client == nullptr)
             {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+                // For ESP-IDF v5.0 and above
+                std::string uri = "mqtt://" + host + ":" + std::to_string(port);
                 esp_mqtt_client_config_t mqtt_cfg = {};
-
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
-                std::string uri = "mqtt://" + (!username.empty() ? username + ":" + password + "@" : "") + host + ":" + std::to_string(port);
-                mqtt_cfg.uri = uri.c_str();
+                mqtt_cfg.broker.address.uri = uri.c_str();
+                if (!username.empty())
+                {
+                    mqtt_cfg.credentials.username = username.c_str();
+                    mqtt_cfg.credentials.authentication.password = password.c_str();
+                }
 #else
+                // For ESP-IDF versions below v5.0
+                esp_mqtt_client_config_t mqtt_cfg = {};
                 mqtt_cfg.host = host.c_str();
                 mqtt_cfg.port = port;
                 if (!username.empty())
@@ -59,10 +66,10 @@ namespace esphome
                     mqtt_cfg.password = password.c_str();
                 }
 #endif
-
                 mqtt_client = esp_mqtt_client_init(&mqtt_cfg);
                 esp_mqtt_client_start(mqtt_client);
             }
+
 #endif
         }
 

--- a/components/samsung_ac/debug_mqtt.cpp
+++ b/components/samsung_ac/debug_mqtt.cpp
@@ -45,10 +45,21 @@ namespace esphome
 #elif defined(USE_ESP32)
             if (mqtt_client == nullptr)
             {
-                std::string uri = "mqtt://" + (!username.empty() ? username + ":" + password + "@" : "") + host + ":" + std::to_string(port);
-
                 esp_mqtt_client_config_t mqtt_cfg = {};
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+                std::string uri = "mqtt://" + (!username.empty() ? username + ":" + password + "@" : "") + host + ":" + std::to_string(port);
                 mqtt_cfg.uri = uri.c_str();
+#else
+                mqtt_cfg.host = host.c_str();
+                mqtt_cfg.port = port;
+                if (!username.empty())
+                {
+                    mqtt_cfg.username = username.c_str();
+                    mqtt_cfg.password = password.c_str();
+                }
+#endif
+
                 mqtt_client = esp_mqtt_client_init(&mqtt_cfg);
                 esp_mqtt_client_start(mqtt_client);
             }


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [x] 🐞 Bug Fix
- [ ] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

This PR resolves the compatibility issues with the `debug_mqtt.cpp` file when using ESP-IDF framework in ESPHome 2024.12.x. The changes include updates to the `esp_mqtt_client_config_t` structure to align with the updated ESP-IDF framework API.

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
1. Replaced deprecated `mqtt_cfg.host`, `mqtt_cfg.port`, `mqtt_cfg.username`, and `mqtt_cfg.password` members with the updated configuration structure.
2. Updated `debug_mqtt_connect` function to reflect the new API changes.
3. Ensured backward compatibility for Arduino framework.

---

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: #242 

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2024.12.2
- **Home Assistant Version**: 2024.12.5

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: 
- **Outdoor Unit Model**: 
- **ESP Device Model**: M5STACK ATOM Lite + M5STACK RS-485
- **Wiring Configuration**: F1/F2

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. Tested with an ESP32 device using ESP-IDF framework.
2. Verified MQTT connectivity to broker with credentials and port settings.
3. Ensured backward compatibility with Arduino framework.

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->
- **Logs from ESPHome with ESP-IDF**:
```
[INFO] Successfully connected to MQTT broker [DEBUG] Publishing to topic: samsung_ac/nasa
```
- **Logs from ESPHome with Arduino framework**:
```
[INFO] Successfully connected to MQTT broker [DEBUG] Publishing to topic: samsung_ac/nasa
```

---

## 🛠️ **YAML Configuration**
```yaml
external_components:
  - source: github://omerfaruk-aran/esphome_samsung_hvac_bus@fix/mqtt-espidf-compatibility
    components: [samsung_ac]

samsung_ac:

  # Sends all NASA package values to MQTT so the can be analysed or monitored.
  debug_mqtt_host: 192.168.1.100
  debug_mqtt_port: 1883
  debug_mqtt_username: mqtt_user
  debug_mqtt_password: mqtt_pass

    ...
```