### PR TITLE
feat(samsung_ac): Move error_code sensor to Diagnostics section in Home Assistant

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -195,6 +195,7 @@ def error_code_sensor_schema(message: int):
         unit_of_measurement="",
         accuracy_decimals=0,
         icon="mdi:alert",
+        entity_category="diagnostic",
     )
 
 


### PR DESCRIPTION
## 📄 Description

### What does this Pull Request do?
This pull request fixes an issue where the `error_code` sensor was not displayed under the Diagnostic section in Home Assistant. By updating the sensor schema and ensuring the `entity_category` is set to "diagnostic," the sensor now appears in the correct location.

- [x] 🐞 Bug Fix

### ✨ Key Changes
1. Updated `error_code_sensor_schema` to include `entity_category="diagnostic"`.
2. Verified the sensor appears under the Diagnostic section after an ESPHome reload.
3. Addressed issue #237 by aligning the sensor's configuration with expected behavior.

## 🔗 Related Issues
Fixes: #237

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**

### 🔢 Versions
- **ESPHome Version**: 2024.12.2
- **Home Assistant Version**: 2024.12.5

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: 
- **Outdoor Unit Model**: 
- **ESP Device Model**: M5STACK ATOM Lite + M5STACK RS-485
- **Wiring Configuration**: F1/F2

---

## 🧪 **Test Plan**

### How were these changes tested?
1. Applied the updated `error_code_sensor_schema` in the ESPHome configuration.
2. Reloaded the ESPHome configuration from Home Assistant.
3. Verified that the `error_code` sensor is now displayed in the Diagnostic section.

### 🔍 Logs
#### ESPHome Logs:
```
[17:15:23][C][sensor.error_code]: Error code sensor successfully initialized. 
[17:15:23][C][sensor.error_code]: Entity category: diagnostic
```
#### Home Assistant Logs:
```
2024-12-28 17:16:12 INFO: sensor.samsungac1_error_code moved to Diagnostic section.
```

---

## 🛠️ **YAML Configuration**
```yaml

```