### PR TITLE
Fix: does not compile on host platform

### DIFF
--- a/components/samsung_ac/debug_mqtt.cpp
+++ b/components/samsung_ac/debug_mqtt.cpp
@@ -15,6 +15,7 @@ namespace esphome
     {
         bool debug_mqtt_connected()
         {
+#if defined(USE_ESP8266) || defined(USE_ESP32)
             if (mqtt_client == nullptr)
                 return false;
 
@@ -22,6 +23,9 @@ namespace esphome
             return mqtt_client->connected();
 #elif defined(USE_ESP32)
             return true;
+#endif
+#else
+        return false;
 #endif
         }
 
@@ -75,6 +79,7 @@ namespace esphome
 
         bool debug_mqtt_publish(const std::string &topic, const std::string &payload)
         {
+#if defined(USE_ESP8266) || defined(USE_ESP32)
             if (mqtt_client == nullptr)
                 return false;
 
@@ -82,6 +87,9 @@ namespace esphome
             return mqtt_client->publish(topic.c_str(), 0, false, payload.c_str()) != 0;
 #elif defined(USE_ESP32)
             return esp_mqtt_client_publish(mqtt_client, topic.c_str(), payload.c_str(), payload.length(), 0, false) != -1;
+#endif
+#else
+        return false
 #endif
         }
     } // namespace samsung_ac


### PR DESCRIPTION
fixing
Compiling .pioenvs/host-platform-bug/src/esphome/components/samsung_ac/debug_mqtt.o src/esphome/components/samsung_ac/debug_mqtt.cpp: In function ‘bool esphome::samsung_ac::debug_mqtt_connected()’: src/esphome/components/samsung_ac/debug_mqtt.cpp:18:17: error: ‘mqtt_client’ was not declared in this scope
   18 |             if (mqtt_client == nullptr)
      |                 ^~~~~~~~~~~

## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [x] 🐞 Bug Fix
- [ ] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
ifdef's mqtt_client on (mqtt) unsupported platforms

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: #262 
Related: 

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [x] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**:  2024.10.2
- **Home Assistant Version**:

### 🧩 Devices
- **Air Conditioner Type**:
  - [ ] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: (e.g., AR09TXFCAWKNEU)
- **Outdoor Unit Model**: (e.g., AJ050TXJ2KH/EA)
- **ESP Device Model**: (e.g., M5STACK ATOM Lite + M5STACK RS-485)
- **Wiring Configuration**: (e.g., F1/F2)

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. esphome compile  bug.yaml

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->

---

## 🛠️ **YAML Configuration**
```yaml
# Please provide the relevant YAML configuration you used for testing this PR
esphome:
  name: host-platform-bug

host: # runs directly on x86_64
  mac_address: "12:34:56:78:90:ab"

uart:
  port: /dev/ttyUSB0
  baud_rate: 9600
  parity: EVEN

external_components:
  - source: github://omerfaruk-aran/esphome_samsung_hvac_bus@main

samsung_ac:
  devices:
```
