### PR TITLE
Control pin for DI-DE-RE-RO RS485 adapters

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -19,8 +19,11 @@ from esphome.const import (
     CONF_UNIT_OF_MEASUREMENT,
     CONF_DEVICE_CLASS,
     CONF_FILTERS,
+    CONF_FLOW_CONTROL_PIN,
 )
 from esphome.core import CORE, Lambda
+from esphome.cpp_helpers import gpio_pin_expression
+from esphome import pins
 
 CODEOWNERS = ["matthias882", "lanwin", "omerfaruk-aran"]
 DEPENDENCIES = ["uart"]
@@ -329,6 +332,7 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(Samsung_AC),
             # cv.Optional(CONF_PAUSE, default=False): cv.boolean,
+            cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DEBUG_MQTT_HOST, default=""): cv.string,
             cv.Optional(CONF_DEBUG_MQTT_PORT, default=1883): cv.int_,
             cv.Optional(CONF_DEBUG_MQTT_USERNAME, default=""): cv.string,
@@ -352,6 +356,10 @@ async def to_code(config):
         cg.add_library("heman/AsyncMqttClient-esphome", "2.0.0")
 
     var = cg.new_Pvariable(config[CONF_ID])
+    if CONF_FLOW_CONTROL_PIN in config:
+        pin = await gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
+        cg.add(var.set_flow_control_pin(pin))
+
     for device_index, device in enumerate(config[CONF_DEVICES]):
         var_dev = cg.new_Pvariable(
             device[CONF_DEVICE_ID], device[CONF_DEVICE_ADDRESS], var

--- a/components/samsung_ac/samsung_ac.cpp
+++ b/components/samsung_ac/samsung_ac.cpp
@@ -14,6 +14,10 @@ namespace esphome
       {
         ESP_LOGW(TAG, "setup");
       }
+      if (this->flow_control_pin_ != nullptr)
+      {
+        this->flow_control_pin_->setup();
+      }
     }
 
     void Samsung_AC::update()
@@ -84,13 +88,26 @@ namespace esphome
 
     void Samsung_AC::dump_config()
     {
+      ESP_LOGCONFIG(TAG, "Samsung_AC:");
+      LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
     }
 
     void Samsung_AC::publish_data(std::vector<uint8_t> &data)
     {
       ESP_LOGW(TAG, "write %s", bytes_to_hex(data).c_str());
+
+      if (this->flow_control_pin_ != nullptr) {
+        ESP_LOGD(TAG, "switching flow_control_pin to write");
+        this->flow_control_pin_->digital_write(true);
+        }
+
       this->write_array(data);
       this->flush();
+
+      if (this->flow_control_pin_ != nullptr) {
+        ESP_LOGD(TAG, "switching flow_control_pin to read");
+        this->flow_control_pin_->digital_write(false);
+        }
     }
 
     void Samsung_AC::loop()

--- a/components/samsung_ac/samsung_ac.h
+++ b/components/samsung_ac/samsung_ac.h
@@ -50,6 +50,11 @@ namespace esphome
         }
       }
 
+      void set_flow_control_pin(GPIOPin *flow_control_pin)
+      {
+        this->flow_control_pin_ = flow_control_pin;
+      }
+
       void set_debug_mqtt(std::string host, int port, std::string username, std::string password)
       {
         debug_mqtt_host = host;
@@ -240,6 +245,7 @@ namespace esphome
       bool data_processing_init = true;
 
       // settings from yaml
+      GPIOPin *flow_control_pin_{nullptr};
       std::string debug_mqtt_host = "";
       uint16_t debug_mqtt_port = 1883;
       std::string debug_mqtt_username = "";

--- a/example.yaml
+++ b/example.yaml
@@ -62,6 +62,10 @@ samsung_ac:
   # When enabled (set to true), this option logs messages associated with defined codes on the device. This helps in monitoring the behavior of the device by recording the activity related to known, expected codes.
   debug_log_messages: false
 
+  # For half duplex RS485 board with DI, DE, RE, and RO pins, you have to control read/write with control pin
+  # see https://microcontrollerslab.com/rs485-serial-communication-esp32-esp8266-tutorial/ for wiring
+  #flow_control_pin: GPIO4
+
   # Capabilities configure the features that all devices of your AC system have (all parts of this section are optional). 
   # All capabilities are off by default, you need to enable only those your devices have.
   # You can override or configure them also on a per-device basis (look below for that).


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [ ] 🐞 Bug Fix
- [x] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
1. added `flow_control_pin` configuration for half duplex RS485 boards
2. ...
3. ...

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: 
Related: 

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [x] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [x] Documentation has been updated (if necessary) 📖
- [x] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 
- **Home Assistant Version**: 

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: (e.g., AR09TXFCAWKNEU)
- **Outdoor Unit Model**: (e.g., AJ050TXJ2KH/EA)
- **ESP Device Model**: (e.g., M5STACK ATOM Lite + M5STACK RS-485)
- **Wiring Configuration**: (e.g., F1/F2)

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. ...

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->

---

## 🛠️ **YAML Configuration**
```yaml
# Please provide the relevant YAML configuration you used for testing this PR
uart:
  tx_pin: GPIO1  # txd0
  rx_pin: GPIO3  # rxd0
  baud_rate: 9600
  parity: EVEN

samsung_ac:
  flow_control_pin: GPIO4
  devices:
    ...
```
