### PR TITLE
FIX for missing state class on custom sensors

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -144,29 +144,22 @@ CUSTOM_SENSOR_SCHEMA = sensor.sensor_schema().extend(
 
 def custom_sensor_schema(
     message: int,
-    unit_of_measurement=None,
-    icon=None,
-    accuracy_decimals=None,
-    device_class=None,
-    state_class=None,
-    entity_category=None,
+    unit_of_measurement=cv.UNDEFINED,
+    icon=cv.UNDEFINED,
+    accuracy_decimals=cv.UNDEFINED,
+    device_class=cv.UNDEFINED,
+    state_class=cv.UNDEFINED,
+    entity_category=cv.UNDEFINED,
     raw_filters=[],
 ):
-    schema = sensor.sensor_schema()
-    if unit_of_measurement is not None:
-        schema = schema.extend({cv.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string})
-    if icon is not None:
-        schema = schema.extend({cv.Optional("icon"): cv.icon})
-    if accuracy_decimals is not None:
-        schema = schema.extend({cv.Optional("accuracy_decimals"): cv.positive_int})
-    if device_class is not None:
-        schema = schema.extend({cv.Optional(CONF_DEVICE_CLASS): cv.string})
-    if state_class is not None:
-        schema = schema.extend({cv.Optional("state_class"): cv.string})
-    if entity_category is not None:
-        schema = schema.extend({cv.Optional("entity_category"): cv.string})
-
-    schema = schema.extend({
+    schema = sensor.sensor_schema(
+        unit_of_measurement=unit_of_measurement,
+        icon=icon,
+        accuracy_decimals=accuracy_decimals,
+        device_class=device_class,
+        state_class=state_class,
+        entity_category=entity_category
+    ).extend({
         cv.Optional(CONF_DEVICE_CUSTOM_MESSAGE, default=message): cv.hex_int,
         cv.Optional(CONF_DEVICE_CUSTOM_RAW_FILTERS, default=raw_filters): sensor.validate_filters,
     })


### PR DESCRIPTION
Fix for "Entity no longer has a state class" errors with Home Assistant > 2025.6.0 and ESPHome 2025.7.0.

## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [x] 🐞 Bug Fix
- [ ] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
1. ...Updated custom_sensor_schema function in `__init__.py`
2. ...
3. ...

## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: https://github.com/omerfaruk-aran/esphome_samsung_hvac_bus/issues/285
Related: 

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [x] Code compiles without errors 🧑‍💻
- [ ] All tests pass successfully ✅
- [x] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [ ] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2025.7.0
- **Home Assistant Version**: 2025.6

### 🧩 Devices
- **Air Conditioner Type**:
  - [x] NASA
  - [x] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: (e.g., AR09TXFCAWKNEU)
- **Outdoor Unit Model**: (e.g., AJ050TXJ2KH/EA)
- **ESP Device Model**: (e.g., M5STACK ATOM Lite + M5STACK RS-485)
- **Wiring Configuration**: (e.g., F1/F2)

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. ...

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->

---

## 🛠️ **YAML Configuration**
```yaml
# Please provide the relevant YAML configuration you used for testing this PR
```
