### PR TITLE
Fix Non-NASA bus flooding and RS-485 timing issues

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -25,6 +25,25 @@ namespace esphome
         static bool pending_control_tx_ = false;
         static uint32_t pending_control_tx_due_ms_ = 0;
 
+        // Registration rate-limiting: shared by initial registration and the wake-up path.
+        // Both paths must respect the same 10-second minimum interval to avoid spamming
+        // the RS-485 bus with D1 registration packets, which overwhelms the outdoor unit
+        // and forces it to require a hard power-cycle reset.
+        static uint32_t last_reg_attempt_ms_ = 0;
+        constexpr uint32_t REG_MIN_INTERVAL_MS = 10000;
+
+        // Rate-limited wrapper around send_register_controller().
+        // Returns true if a packet was actually sent, false if still within the quiet period.
+        static bool try_send_register_controller(MessageTarget *target)
+        {
+            const uint32_t now = millis();
+            if (now - last_reg_attempt_ms_ < REG_MIN_INTERVAL_MS)
+                return false;
+            last_reg_attempt_ms_ = now;
+            send_register_controller(target);
+            return true;
+        }
+
         // Track cumulative energy calculation per device address
         // Note: Energy tracker persists across device reconnections. This is intentional to maintain
         // cumulative energy across device restarts. The tracker is keyed by device address, so if
@@ -1044,16 +1063,11 @@ namespace esphome
             }
 
             // If we're not currently registered, keep sending a registration request until it has
-            // been confirmed by the outdoor unit.
+            // been confirmed by the outdoor unit. Uses try_send_register_controller() to enforce
+            // the shared 10-second rate limit so this path cannot spam the bus.
             if (!controller_registered)
             {
-                static uint32_t last_reg_attempt = 0;
-                const uint32_t now = millis();
-                if (now - last_reg_attempt > 10000) // wait 10.000 ms (10 seconds)
-                {
-                    send_register_controller(target);
-                    last_reg_attempt = now;
-                }
+                try_send_register_controller(target);
             }
 
             // If we have *any* messages in the queue for longer than 15s, assume failure and
@@ -1076,7 +1090,8 @@ namespace esphome
 
             // If we have any *unsent* messages in the queue for over 1000ms, it likely means the indoor
             // and/or outdoor unit has gone to sleep due to inactivity. Send a registration request to
-            // wake the unit up.
+            // wake the unit up. Uses try_send_register_controller() to enforce the shared 10-second
+            // rate limit, preventing this path from spamming the bus when a command is pending.
             for (auto &item : nonnasa_requests)
             {
                 if (item.time_sent == 0 && now - item.time > 1000 && item.resend_count == 0 && item.retry_count == 0)
@@ -1085,7 +1100,7 @@ namespace esphome
                     indoor_unit_awake = false;
                     item.retry_count++;
                     LOGD("Device is likely sleeping, waking...");
-                    send_register_controller(target);
+                    try_send_register_controller(target);
                     break;
                 }
             }

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -1047,7 +1047,13 @@ namespace esphome
             // been confirmed by the outdoor unit.
             if (!controller_registered)
             {
-                send_register_controller(target);
+                static uint32_t last_reg_attempt = 0;
+                const uint32_t now = millis();
+                if (now - last_reg_attempt > 10000) // wait 10.000 ms (10 seconds)
+                {
+                    send_register_controller(target);
+                    last_reg_attempt = now;
+                }
             }
 
             // If we have *any* messages in the queue for longer than 15s, assume failure and

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -1031,14 +1031,18 @@ namespace esphome
 
         void NonNasaProtocol::protocol_update(MessageTarget *target)
         {
-            // non-blocking keepalive send (scheduled from broadcast request)
+            // non-blocking keepalive send (scheduled from broadcast request).
+            // Uses try_send_register_controller() to enforce the shared 10-second rate limit
+            // so the keepalive cannot fire back-to-back with an initial registration or wake-up send.
             if (non_nasa_keepalive && pending_keepalive_)
             {
                 const uint32_t now = millis();
                 if ((int32_t)(now - pending_keepalive_due_ms_) >= 0)
                 {
-                    send_register_controller(target);
-                    last_keepalive_sent_ms_ = now;
+                    if (try_send_register_controller(target))
+                    {
+                        last_keepalive_sent_ms_ = now;
+                    }
                     pending_keepalive_ = false;
                 }
             }

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -36,10 +36,13 @@ namespace esphome
 
         // Rate-limited wrapper around send_register_controller().
         // Returns true if a packet was actually sent, false if still within the quiet period.
+        // last_reg_attempt_ms_ == 0 means "never sent"; the first attempt is always allowed
+        // through immediately. Subsequent attempts are rate-limited to REG_MIN_INTERVAL_MS.
         static bool try_send_register_controller(MessageTarget *target)
         {
             const uint32_t now = millis();
-            if (now - last_reg_attempt_ms_ < REG_MIN_INTERVAL_MS)
+            if (last_reg_attempt_ms_ != 0 &&
+                now - last_reg_attempt_ms_ < REG_MIN_INTERVAL_MS)
                 return false;
             last_reg_attempt_ms_ = now;
             send_register_controller(target);

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -25,6 +25,8 @@ namespace esphome
         static bool pending_control_tx_ = false;
         static uint32_t pending_control_tx_due_ms_ = 0;
 
+        void send_register_controller(MessageTarget *target);
+
         // Registration rate-limiting: shared by initial registration and the wake-up path.
         // Both paths must respect the same 10-second minimum interval to avoid spamming
         // the RS-485 bus with D1 registration packets, which overwhelms the outdoor unit

--- a/components/samsung_ac/samsung_ac.cpp
+++ b/components/samsung_ac/samsung_ac.cpp
@@ -242,6 +242,12 @@ namespace esphome
     void Samsung_AC::after_write()
     {
       if (this->flow_control_pin_ != nullptr) {
+        // At 9600 baud, flush() drains the TX FIFO but the UART shift register still
+        // has up to ~1.15ms of bits in flight. Pulling DE/RE low before the last byte
+        // finishes transmitting corrupts the trailing bits on the RS-485 bus and can
+        // cause CRC errors at the receiver, eventually crashing the outdoor unit.
+        // 3ms is a safe margin (≈ 2.5 byte-times at 9600 baud) with negligible bus impact.
+        delayMicroseconds(3000);
         LOGD("switching flow_control_pin to read");
         this->flow_control_pin_->digital_write(false);
       }

--- a/explanation.md
+++ b/explanation.md
@@ -1,3 +1,0 @@
-I've reviewed your fix and the `protocol_non_nasa.cpp` code. Your addition of the 10-second timer is **spot on** and addresses the most likely cause of the outdoor unit locking up.
-
-Here is why your fix works, along with other potential causes for the outdoor unit freezing.

--- a/explanation.md
+++ b/explanation.md
@@ -1,0 +1,3 @@
+I've reviewed your fix and the `protocol_non_nasa.cpp` code. Your addition of the 10-second timer is **spot on** and addresses the most likely cause of the outdoor unit locking up.
+
+Here is why your fix works, along with other potential causes for the outdoor unit freezing.


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [X] 🐞 Bug Fix
- [ ] ✨ New Feature
- [X] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
**Description:** 
This PR addresses recurring stability issues where the Samsung HVAC outdoor unit becomes unresponsive (requiring a module physical disconnection from the bus) when using the Non-NASA protocol.

**Changes:**
1. Unified Registration Rate-Limiting: Implemented a shared 10-second rate limiter for all registration (D1) packet paths. Previously, the "wake-up" and "keepalive" loops could bypass the startup timer, leading to bus flooding (up to 50 packets/sec) which overwhelmed the HVAC unit's MCU.
2. RS-485 Transmission Delay: Added a 3ms delay in after_write() before dropping the DE/RE flow control pin. At 9600 baud, flush() drains the TX FIFO but the UART shift register still has bits in flight. Dropping the pin immediately was corrupting the tail of every frame, causing CRC errors and eventual communication lockups.

Result: Improved communication reliability and prevented the "zombie" state where the outdoor unit stops responding to all bus traffic.

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [X] Code compiles without errors 🧑‍💻
- [X] All tests pass successfully ✅
- [X] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [X] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2025.12.5
- **Home Assistant Version**: 2026.3.1

### 🧩 Devices
- **Air Conditioner Type**:
  - [ ] NASA
  - [X] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: AR12KSFHBWKNET
- **Outdoor Unit Model**: n/a
- **ESP Device Model**: WAVESHARE ESP32-S3-RS485-CAN
- **Wiring Configuration**: F1/F2

---

## 🧪 **Test Plan**
### How were these changes tested?
Flashed the esp with the modified code and it started working again, no disconnection or reboot needed.

## 🛠️ **YAML Configuration**

```yaml
# This example provides a basic configuration and description based on the M5STACK components
# For further configuration you should visit the ESPHome docs https://esphome.io
# Every line starting with a # can be removed.

## BASIC CONFIGURATION
esphome:
  name: samsung_ac
  friendly_name: SamsungAC

# Select chipset and board configuration - in this case M5STACK
esp32:
  board: esp32-s3-devkitc-1
  flash_size: 16MB
  cpu_frequency: 240MHz
  framework:
    type: esp-idf

# [Optional] - Create web interface where you can control the AC from your web browser (without Home Assistant)
web_server:
  port: 80

# Enable logging
logger:
  baud_rate: 0
  logs:
    component: ERROR # Remove the "Your component takes to long to respond warning"

# Enable native API for communication with Home Assistant, this can be removed if you do not plan to use it with Home Assistant
api:

# Enable OTA firmware update, you will be able to upload the firmware over WiFi without connecting the device by cables
ota:
  platform: esphome

# Setup your WiFi password
wifi:
  ssid: "******"
  password: "******"

captive_portal:

# Specify pins used by the board to comunicate with RS485 board - in this case M5STACK
uart:
  tx_pin: GPIO17   # Use GPIO26 for ATOM Tail485 
  rx_pin: GPIO18   # Use GPIO32 for ATOM Tail485
  # For older devices it could also be 2400. But you should start with 9600.
  baud_rate: 9600
  parity: EVEN

## SAMSUNG AC CONFIGURATION

# Import custom component from GitHub
external_components:
  - source: github://chsln/esphome_samsung_hvac_bus@main
    components: [samsung_ac]

# Configuration of AC component
samsung_ac:
  flow_control_pin: GPIO21
  
  # non_nasa_keepalive: Prevents some Non-NASA units from sleeping when idle.
  # This increases bus traffic slightly; disable if you don't need idle telemetry.
  non_nasa_keepalive: true

  # Enable 'debug_log_messages_on_change' to log sensor data changes within 120 seconds
  # When set to true, this option logs the sensor data only when the value changes within a 120-second interval,
  # reducing redundant log messages and focusing on real-time data changes.
  debug_log_messages_on_change: true  # Enable log messages on change within 120 seconds
  
  # When enabled (set to true), this option will log the messages associated with undefined codes on the device. This is useful for debugging and identifying any unexpected or unknown codes that the device may receive during operation.
  debug_log_undefined_messages: false
  
  # When enabled (set to true), this option logs messages associated with defined codes on the device. This helps in monitoring the behavior of the device by recording the activity related to known, expected codes.
  debug_log_messages: false

  # For half duplex RS485 board with DI, DE, RE, and RO pins, you have to control read/write with control pin
  # see https://microcontrollerslab.com/rs485-serial-communication-esp32-esp8266-tutorial/ for wiring
  #flow_control_pin: GPIO4

  # Capabilities: Define which features your AC system supports.
  # - fan_modes is enabled by default (fan speed controls will be shown in HA)
  # - vertical_swing and horizontal_swing are disabled by default
  # You can set these globally here, or override per indoor unit under `devices:`
  capabilities:
    fan_modes: true
    vertical_swing: true
    horizontal_swing: true
    # Presets define special AC modes like Windfree, Eco, and so on. 
    # The following modes are available: sleep, quiet, fast, longreach, windfree, eco.
    presets: 
      # Short version - a quick and simple way to enable presets.
      quiet: true
      # Long version - allows customization, including localized names and control over enabling the presets.
      fast:
        name: "Fast cooling"
        enabled: true

  devices:

    # -----------------------------------------------------------------------
    # INDOOR UNIT 1 (Address 00)
    # -----------------------------------------------------------------------
    - address: "00"
      climate:
        name: "AC Indoor 00"
      room_temperature:
        name: "AC Indoor 00 Temp"
      
    # -----------------------------------------------------------------------
    # INDOOR UNIT 2 (Address 01)
    # -----------------------------------------------------------------------
    - address: "01"
      climate:
        name: "AC Indoor 01"
      room_temperature:
        name: "AC Indoor 01 Temp"

    # -----------------------------------------------------------------------
    # INDOOR UNIT 3 (Address 02)
    # -----------------------------------------------------------------------
    - address: "02"
      climate:
        name: "AC Indoor 02"
      room_temperature:
        name: "AC Indoor 02 Temp"

    # -----------------------------------------------------------------------
    # OUTDOOR UNIT (Address c8)
    # -----------------------------------------------------------------------
    - address: "c8"
      outdoor_temperature:
        name: "Outdoor Temperature"
      outdoor_instantaneous_power:
        name: "Outdoor Power Usage"
      error_code:
        name: "AC Error Code"
```
