### PR TITLE
Refactor Samsung AC climate control implementation

### DIFF
--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -34,7 +34,7 @@ namespace esphome
                                         climate::CLIMATE_FAN_AUTO});
 
         static const char *CUSTOM_FAN_MODES[] = {"Turbo"};
-        traits.set_supported_custom_fan_modes(CUSTOM_FAN_MODES);
+        this->set_supported_custom_fan_modes(CUSTOM_FAN_MODES);
       }
 
       {
@@ -58,7 +58,7 @@ namespace esphome
 
           if (!custom_presets.empty())
           {
-            traits.set_supported_custom_presets(custom_presets);
+            this->set_supported_custom_presets(custom_presets);
           }
         }
       }
@@ -200,7 +200,3 @@ namespace esphome
 
   } // namespace samsung_ac
 } // namespace esphome
-
-
-
-


### PR DESCRIPTION
## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [✅] 🐞 Bug Fix
- [ ] ✨ New Feature
- [✅] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
1. Refactor Samsung AC climate control implementation


## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: Fixes #365 
Related: Deprecated function calls while compiling

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [✅] Code compiles without errors 🧑‍💻
- [✅] All tests pass successfully ✅
- [✅] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [✅] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 2026.6.5
- **Home Assistant Version**: 2026.7.2

### 🧩 Devices
- **Air Conditioner Type**:
  - [✅] NASA
  - [ ] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: AE036BNMPEHEU
- **ESP Device Model**: M5STACK ATOM Lite + M5STACK RS-485
- **Wiring Configuration**: F1/F2   V1/V2

