### PR TITLE
fix: correct Cmd20 diagnostic logging

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -822,10 +822,10 @@ namespace esphome
                         log_should_print(log_dedup_key(nonpacket_.src, "nonnasa", 0x0020), (double)sig, 0.0, 0))
                     {
 
-                        LOGI("Cmd20 received: src=%s, wind_direction=%d, target_temp=%d, power=%d, mode=%d, fanspeed=%d",
+                        LOGI("Cmd20 received: src=%s, wind_direction=%d, target_temp=%s, power=%d, mode=%d, fanspeed=%d",
                              nonpacket_.src.c_str(),
                              (uint8_t)nonpacket_.command20.wind_direction,
-                             nonpacket_.command20.target_temp,
+                             nonpacket_.command20.target_temp.to_string().c_str(),
                              nonpacket_.command20.power,
                              (uint8_t)nonpacket_.command20.mode,
                              (uint8_t)nonpacket_.command20.fanspeed);


### PR DESCRIPTION
## Summary

Correct the existing Cmd20 target-temperature diagnostic so a structured
Temperature object is no longer passed to an integer printf conversion.

The log now uses Temperature's unit-aware string representation. Packet parsing,
request matching, state publication, control flow, log level, and log frequency
remain unchanged.

This removes a printf format/type mismatch without changing protocol behavior.

## Validation

- `./test/test_non_nasa.sh`
- `./test/test_nasa.sh`
- `git diff --check`

Both test suites pass.

## Dependencies

None.