### PR TITLE
Add NASA filter reset support

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -95,6 +95,7 @@ CONF_DEVICE_OUT_SENSOR_VOLTAGE = "outdoor_voltage"
 CONF_MAP_AUTO_TO_HEAT_COOL = "map_auto_to_heat_cool"
 CONF_DEBUG_LOG_MESSAGES_ON_CHANGE = "debug_log_messages_on_change"
 CONF_NON_NASA_TX_DELAY_MS = "non_nasa_tx_delay_ms"
+CONF_DEVICE_FILTER_RESET = "filter_reset"
 
 CONF_CAPABILITIES = "capabilities"
 CONF_CAPABILITIES_FAN_MODES = "fan_modes"
@@ -280,6 +281,9 @@ DEVICE_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_DEVICE_AUTOMATIC_CLEANING): switch.switch_schema(
             Samsung_AC_Switch, icon="mdi:broom"
+        ),
+        cv.Optional(CONF_DEVICE_FILTER_RESET): switch.switch_schema(
+             Samsung_AC_Switch, icon="mdi:air-filter"
         ),
         cv.Optional(CONF_DEVICE_WATER_HEATER_POWER): switch.switch_schema(
             Samsung_AC_Switch
@@ -488,6 +492,10 @@ async def to_code(config):
             CONF_DEVICE_AUTOMATIC_CLEANING: (
                 switch.new_switch,
                 var_dev.set_automatic_cleaning_switch,
+            ),
+            CONF_DEVICE_FILTER_RESET: (
+               switch.new_switch,
+                var_dev.set_filter_reset_switch,
             ),
             CONF_DEVICE_WATER_HEATER_POWER: (
                 switch.new_switch,

--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -96,7 +96,6 @@ CONF_MAP_AUTO_TO_HEAT_COOL = "map_auto_to_heat_cool"
 CONF_DEBUG_LOG_MESSAGES_ON_CHANGE = "debug_log_messages_on_change"
 CONF_NON_NASA_TX_DELAY_MS = "non_nasa_tx_delay_ms"
 CONF_DEVICE_FILTER_RESET = "filter_reset"
-CONF_DEVICE_FILTER_WARNING_TEST = "filter_warning_test"
 
 CONF_CAPABILITIES = "capabilities"
 CONF_CAPABILITIES_FAN_MODES = "fan_modes"
@@ -285,9 +284,6 @@ DEVICE_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_DEVICE_FILTER_RESET): switch.switch_schema(
              Samsung_AC_Switch, icon="mdi:air-filter"
-        ),
-        cv.Optional(CONF_DEVICE_FILTER_WARNING_TEST): switch.switch_schema(
-            Samsung_AC_Switch, icon="mdi:alert"
         ),
         cv.Optional(CONF_DEVICE_WATER_HEATER_POWER): switch.switch_schema(
             Samsung_AC_Switch
@@ -500,10 +496,6 @@ async def to_code(config):
             CONF_DEVICE_FILTER_RESET: (
                switch.new_switch,
                 var_dev.set_filter_reset_switch,
-            ),
-            CONF_DEVICE_FILTER_WARNING_TEST: (
-                switch.new_switch,
-                var_dev.set_filter_warning_test_switch,
             ),
             CONF_DEVICE_WATER_HEATER_POWER: (
                 switch.new_switch,

--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -96,6 +96,7 @@ CONF_MAP_AUTO_TO_HEAT_COOL = "map_auto_to_heat_cool"
 CONF_DEBUG_LOG_MESSAGES_ON_CHANGE = "debug_log_messages_on_change"
 CONF_NON_NASA_TX_DELAY_MS = "non_nasa_tx_delay_ms"
 CONF_DEVICE_FILTER_RESET = "filter_reset"
+CONF_DEVICE_FILTER_WARNING_TEST = "filter_warning_test"
 
 CONF_CAPABILITIES = "capabilities"
 CONF_CAPABILITIES_FAN_MODES = "fan_modes"
@@ -284,6 +285,9 @@ DEVICE_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_DEVICE_FILTER_RESET): switch.switch_schema(
              Samsung_AC_Switch, icon="mdi:air-filter"
+        ),
+        cv.Optional(CONF_DEVICE_FILTER_WARNING_TEST): switch.switch_schema(
+            Samsung_AC_Switch, icon="mdi:alert"
         ),
         cv.Optional(CONF_DEVICE_WATER_HEATER_POWER): switch.switch_schema(
             Samsung_AC_Switch
@@ -496,6 +500,10 @@ async def to_code(config):
             CONF_DEVICE_FILTER_RESET: (
                switch.new_switch,
                 var_dev.set_filter_reset_switch,
+            ),
+            CONF_DEVICE_FILTER_WARNING_TEST: (
+                switch.new_switch,
+                var_dev.set_filter_warning_test_switch,
             ),
             CONF_DEVICE_WATER_HEATER_POWER: (
                 switch.new_switch,

--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -4,6 +4,7 @@ from esphome.components import (
     uart,
     sensor,
     binary_sensor,
+    button,
     switch,
     select,
     number,
@@ -37,7 +38,7 @@ from esphome import pins
 
 CODEOWNERS = ["matthias882", "lanwin", "omerfaruk-aran"]
 DEPENDENCIES = ["uart"]
-AUTO_LOAD = ["sensor", "binary_sensor", "switch", "select", "number", "climate", "text_sensor"]
+AUTO_LOAD = ["sensor", "binary_sensor", "button", "switch", "select", "number", "climate", "text_sensor"]
 MULTI_CONF = False
 
 CONF_SAMSUNG_AC_ID = "samsung_ac_id"
@@ -45,6 +46,7 @@ CONF_SAMSUNG_AC_ID = "samsung_ac_id"
 samsung_ac = cg.esphome_ns.namespace("samsung_ac")
 Samsung_AC = samsung_ac.class_("Samsung_AC", cg.PollingComponent, uart.UARTDevice)
 Samsung_AC_Device = samsung_ac.class_("Samsung_AC_Device")
+Samsung_AC_Button = samsung_ac.class_("Samsung_AC_Button", button.Button)
 Samsung_AC_Switch = samsung_ac.class_("Samsung_AC_Switch", switch.Switch)
 Samsung_AC_Mode_Select = samsung_ac.class_("Samsung_AC_Mode_Select", select.Select)
 Samsung_AC_Water_Heater_Mode_Select = samsung_ac.class_(
@@ -242,6 +244,12 @@ def error_code_sensor_schema(message: int):
     )
 
 
+def validate_device(config):
+    if CONF_DEVICE_FILTER_RESET in config and len(config[CONF_DEVICE_ADDRESS]) == 2:
+        raise cv.Invalid("filter_reset is only supported for NASA devices")
+    return config
+
+
 DEVICE_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_DEVICE_ID): cv.declare_id(Samsung_AC_Device),
@@ -282,8 +290,8 @@ DEVICE_SCHEMA = cv.Schema(
         cv.Optional(CONF_DEVICE_AUTOMATIC_CLEANING): switch.switch_schema(
             Samsung_AC_Switch, icon="mdi:broom"
         ),
-        cv.Optional(CONF_DEVICE_FILTER_RESET): switch.switch_schema(
-             Samsung_AC_Switch, icon="mdi:air-filter"
+        cv.Optional(CONF_DEVICE_FILTER_RESET): button.button_schema(
+            Samsung_AC_Button, icon="mdi:air-filter"
         ),
         cv.Optional(CONF_DEVICE_WATER_HEATER_POWER): switch.switch_schema(
             Samsung_AC_Switch
@@ -361,6 +369,7 @@ DEVICE_SCHEMA = cv.Schema(
         ),
     }
 )
+DEVICE_SCHEMA = cv.All(DEVICE_SCHEMA, validate_device)
 
 CUSTOM_SENSOR_KEYS = [
     CONF_DEVICE_WATER_TEMPERATURE,
@@ -494,8 +503,8 @@ async def to_code(config):
                 var_dev.set_automatic_cleaning_switch,
             ),
             CONF_DEVICE_FILTER_RESET: (
-               switch.new_switch,
-                var_dev.set_filter_reset_switch,
+                button.new_button,
+                var_dev.set_filter_reset_button,
             ),
             CONF_DEVICE_WATER_HEATER_POWER: (
                 switch.new_switch,

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -110,7 +110,6 @@ namespace esphome
             optional<bool> power;
             optional<bool> automatic_cleaning;
             optional<bool> filter_reset;
-            optional<bool> filter_warning_test;
             optional<bool> water_heater_power;
             optional<Mode> mode;
             optional<WaterHeaterMode> waterheatermode;

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -109,6 +109,7 @@ namespace esphome
         public:
             optional<bool> power;
             optional<bool> automatic_cleaning;
+            optional<bool> filter_reset;
             optional<bool> water_heater_power;
             optional<Mode> mode;
             optional<WaterHeaterMode> waterheatermode;

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -110,6 +110,7 @@ namespace esphome
             optional<bool> power;
             optional<bool> automatic_cleaning;
             optional<bool> filter_reset;
+            optional<bool> filter_warning_test;
             optional<bool> water_heater_power;
             optional<Mode> mode;
             optional<WaterHeaterMode> waterheatermode;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -535,6 +535,7 @@ namespace esphome
                     automatic_cleaning.value = request.automatic_cleaning.value() ? 1 : 0;
                     packet.messages.push_back(automatic_cleaning);
                 }
+
                 if (request.filter_reset)
                 {
                     MessageSet filter_reset(
@@ -543,6 +544,16 @@ namespace esphome
                     filter_reset.value = 1;
                     packet.messages.push_back(filter_reset);
                 }
+
+                if (request.filter_warning_test)
+                {
+                    MessageSet filter_warning_test(
+                        static_cast<MessageNumber>(0x4027)
+                    );
+                    filter_warning_test.value = 1;
+                    packet.messages.push_back(filter_warning_test);
+                }
+
                 if (request.water_heater_power)
                 {
                     MessageSet waterheaterpower(MessageNumber::ENUM_in_water_heater_power);
@@ -629,7 +640,10 @@ namespace esphome
                 queued.automatic_cleaning = request.automatic_cleaning;
 
             if (request.filter_reset)
-                queued.filter_reset = request.filter_reset;    
+                queued.filter_reset = request.filter_reset;  
+
+            if (request.filter_warning_test)
+                queued.filter_warning_test = request.filter_warning_test;  
 
             if (request.water_heater_power)
                 queued.water_heater_power = request.water_heater_power;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -537,9 +537,7 @@ namespace esphome
                 }
                 if (request.filter_reset)
                 {
-                    MessageSet filter_reset(
-                        static_cast<MessageNumber>(0x4025)
-                    );
+                    MessageSet filter_reset(MessageNumber::NASA_FILTER_CLEAN);
                     filter_reset.value = 1;
                     packet.messages.push_back(filter_reset);
                 }
@@ -629,7 +627,7 @@ namespace esphome
                 queued.automatic_cleaning = request.automatic_cleaning;
 
             if (request.filter_reset)
-                queued.filter_reset = request.filter_reset;    
+                queued.filter_reset = request.filter_reset;
 
             if (request.water_heater_power)
                 queued.water_heater_power = request.water_heater_power;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -535,7 +535,6 @@ namespace esphome
                     automatic_cleaning.value = request.automatic_cleaning.value() ? 1 : 0;
                     packet.messages.push_back(automatic_cleaning);
                 }
-
                 if (request.filter_reset)
                 {
                     MessageSet filter_reset(
@@ -544,16 +543,6 @@ namespace esphome
                     filter_reset.value = 1;
                     packet.messages.push_back(filter_reset);
                 }
-
-                if (request.filter_warning_test)
-                {
-                    MessageSet filter_warning_test(
-                        static_cast<MessageNumber>(0x4027)
-                    );
-                    filter_warning_test.value = 1;
-                    packet.messages.push_back(filter_warning_test);
-                }
-
                 if (request.water_heater_power)
                 {
                     MessageSet waterheaterpower(MessageNumber::ENUM_in_water_heater_power);
@@ -640,10 +629,7 @@ namespace esphome
                 queued.automatic_cleaning = request.automatic_cleaning;
 
             if (request.filter_reset)
-                queued.filter_reset = request.filter_reset;  
-
-            if (request.filter_warning_test)
-                queued.filter_warning_test = request.filter_warning_test;  
+                queued.filter_reset = request.filter_reset;    
 
             if (request.water_heater_power)
                 queued.water_heater_power = request.water_heater_power;

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -535,7 +535,14 @@ namespace esphome
                     automatic_cleaning.value = request.automatic_cleaning.value() ? 1 : 0;
                     packet.messages.push_back(automatic_cleaning);
                 }
-
+                if (request.filter_reset)
+                {
+                    MessageSet filter_reset(
+                        static_cast<MessageNumber>(0x4025)
+                    );
+                    filter_reset.value = 1;
+                    packet.messages.push_back(filter_reset);
+                }
                 if (request.water_heater_power)
                 {
                     MessageSet waterheaterpower(MessageNumber::ENUM_in_water_heater_power);
@@ -620,6 +627,9 @@ namespace esphome
 
             if (request.automatic_cleaning)
                 queued.automatic_cleaning = request.automatic_cleaning;
+
+            if (request.filter_reset)
+                queued.filter_reset = request.filter_reset;    
 
             if (request.water_heater_power)
                 queued.water_heater_power = request.water_heater_power;

--- a/components/samsung_ac/protocol_nasa.h
+++ b/components/samsung_ac/protocol_nasa.h
@@ -82,6 +82,8 @@ namespace esphome
             ENUM_in_louver_hl_swing = 0x4011,
             ENUM_in_louver_lr_swing = 0x407e,
 
+            NASA_FILTER_CLEAN = 0x4025,
+
             ENUM_in_state_humidity_percent = 0x4038,
 
             ENUM_in_alt_mode = 0x4060,

--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -16,7 +16,7 @@ namespace esphome
 
       traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
 
-      traits.set_visual_temperature_step(1);
+      traits.set_visual_temperature_step(0.5);
       traits.set_visual_min_temperature(16);
       traits.set_visual_max_temperature(30);
 

--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -16,7 +16,7 @@ namespace esphome
 
       traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
 
-      traits.set_visual_temperature_step(0.5);
+      traits.set_visual_temperature_step(1);
       traits.set_visual_min_temperature(16);
       traits.set_visual_max_temperature(30);
 

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -137,7 +137,6 @@ namespace esphome
       Samsung_AC_Switch *power{nullptr};
       Samsung_AC_Switch *automatic_cleaning{nullptr};
       Samsung_AC_Switch *filter_reset;
-      Samsung_AC_Switch *filter_warning_test;
       Samsung_AC_Switch *water_heater_power{nullptr};
       Samsung_AC_Mode_Select *mode{nullptr};
       Samsung_AC_Water_Heater_Mode_Select *waterheatermode{nullptr};

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -286,6 +286,23 @@ namespace esphome
         };
       }
 
+      void set_filter_warning_test_switch(Samsung_AC_Switch *switch_)
+      {
+        filter_warning_test = switch_;
+
+        filter_warning_test->write_state_ = [this](bool value)
+        {
+          if (!value)
+            return;
+
+          filter_warning_test->publish_state(true);
+
+          ProtocolRequest request;
+          request.filter_warning_test = true;
+          publish_request(request);
+        };
+      }
+
       void set_water_heater_power_switch(Samsung_AC_Switch *switch_)
       {
         water_heater_power = switch_;

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -275,16 +275,14 @@ namespace esphome
 
         filter_reset->write_state_ = [this](bool value)
         {
-          // Only act when the switch is turned ON.
           if (!value)
             return;
+
+          filter_reset->publish_state(true);
 
           ProtocolRequest request;
           request.filter_reset = true;
           publish_request(request);
-
-          // Return the action switch to OFF immediately.
-          filter_reset->publish_state(false);
         };
       }
 

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -136,6 +136,7 @@ namespace esphome
       Samsung_AC_Number *target_water_temperature{nullptr};
       Samsung_AC_Switch *power{nullptr};
       Samsung_AC_Switch *automatic_cleaning{nullptr};
+      Samsung_AC_Switch *filter_reset;
       Samsung_AC_Switch *water_heater_power{nullptr};
       Samsung_AC_Mode_Select *mode{nullptr};
       Samsung_AC_Water_Heater_Mode_Select *waterheatermode{nullptr};
@@ -265,6 +266,25 @@ namespace esphome
           ProtocolRequest request;
           request.automatic_cleaning = value;
           publish_request(request);
+        };
+      }
+
+      void set_filter_reset_switch(Samsung_AC_Switch *switch_)
+      {
+        filter_reset = switch_;
+
+        filter_reset->write_state_ = [this](bool value)
+        {
+          // Only act when the switch is turned ON.
+          if (!value)
+            return;
+
+          ProtocolRequest request;
+          request.filter_reset = true;
+          publish_request(request);
+
+          // Return the action switch to OFF immediately.
+          filter_reset->publish_state(false);
         };
       }
 

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <algorithm>
 #include "esphome/core/helpers.h"
+#include "esphome/components/button/button.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
@@ -95,6 +96,19 @@ namespace esphome
       }
     };
 
+    class Samsung_AC_Button : public button::Button
+    {
+    public:
+      std::function<void()> press_action_;
+
+    protected:
+      void press_action() override
+      {
+        if (press_action_)
+          press_action_();
+      }
+    };
+
     struct Samsung_AC_Sensor
     {
       uint16_t message_number;
@@ -136,7 +150,7 @@ namespace esphome
       Samsung_AC_Number *target_water_temperature{nullptr};
       Samsung_AC_Switch *power{nullptr};
       Samsung_AC_Switch *automatic_cleaning{nullptr};
-      Samsung_AC_Switch *filter_reset;
+      Samsung_AC_Button *filter_reset{nullptr};
       Samsung_AC_Switch *water_heater_power{nullptr};
       Samsung_AC_Mode_Select *mode{nullptr};
       Samsung_AC_Water_Heater_Mode_Select *waterheatermode{nullptr};
@@ -269,17 +283,11 @@ namespace esphome
         };
       }
 
-      void set_filter_reset_switch(Samsung_AC_Switch *switch_)
+      void set_filter_reset_button(Samsung_AC_Button *button)
       {
-        filter_reset = switch_;
-
-        filter_reset->write_state_ = [this](bool value)
+        filter_reset = button;
+        filter_reset->press_action_ = [this]()
         {
-          if (!value)
-            return;
-
-          filter_reset->publish_state(true);
-
           ProtocolRequest request;
           request.filter_reset = true;
           publish_request(request);

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -137,6 +137,7 @@ namespace esphome
       Samsung_AC_Switch *power{nullptr};
       Samsung_AC_Switch *automatic_cleaning{nullptr};
       Samsung_AC_Switch *filter_reset;
+      Samsung_AC_Switch *filter_warning_test;
       Samsung_AC_Switch *water_heater_power{nullptr};
       Samsung_AC_Mode_Select *mode{nullptr};
       Samsung_AC_Water_Heater_Mode_Select *waterheatermode{nullptr};

--- a/components/samsung_ac/samsung_ac_device.h
+++ b/components/samsung_ac/samsung_ac_device.h
@@ -286,23 +286,6 @@ namespace esphome
         };
       }
 
-      void set_filter_warning_test_switch(Samsung_AC_Switch *switch_)
-      {
-        filter_warning_test = switch_;
-
-        filter_warning_test->write_state_ = [this](bool value)
-        {
-          if (!value)
-            return;
-
-          filter_warning_test->publish_state(true);
-
-          ProtocolRequest request;
-          request.filter_warning_test = true;
-          publish_request(request);
-        };
-      }
-
       void set_water_heater_power_switch(Samsung_AC_Switch *switch_)
       {
         water_heater_power = switch_;

--- a/example.yaml
+++ b/example.yaml
@@ -138,6 +138,10 @@ samsung_ac:
       automatic_cleaning:
         name: "Kitchen automatic clean"
 
+      # NASA only: momentary action that sends the filter-clean reset command (0x4025).
+      filter_reset:
+        name: "Kitchen reset filter"
+
       # If your AC sits near or inside the ceiling, the reported room temperature is often a little bit heigher then whats 
       # measured below. This property can be used to correct that value.
       room_temperature_offset: -1.4
@@ -169,6 +173,14 @@ samsung_ac:
       custom_sensor:
         - name: "Kitchen custom value"
           message: 0x1234
+
+        # NASA only: filter warning message (0x4027), exposed through the
+        # existing generic binary custom sensor functionality.
+        - name: "Kitchen filter warning"
+          message: 0x4027
+          type: binary
+          device_class: problem
+          entity_category: diagnostic
 
         # Set type: binary to expose a bus message as a binary_sensor.
         # Binary custom sensors publish false when the decoded value is 0,


### PR DESCRIPTION
## 📄 Description

### What does this Pull Request do?

* [ ] 🐞 Bug Fix
* [x] ✨ New Feature
* [x] 🔨 Code Improvement
* [x] 📚 Documentation Update

Adds NASA-only Samsung HVAC filter reset support.

### ✨ Key Changes

1. Added `filter_reset` as a momentary ESPHome button.
2. Added support for sending the NASA filter-clean command `0x4025`.
3. Added the named `NASA_FILTER_CLEAN` message enum instead of using a raw message number.
4. Restricted `filter_reset` to NASA devices.
5. Updated `example.yaml` to demonstrate:

   * the new filter reset button
   * the existing `0x4027` filter warning message through the generic binary custom sensor support

### Notes

* `0x4027` filter warning support already exists through the generic binary custom sensor implementation and is not introduced by this PR.
* Outdoor telemetry support is already present in the base branch and is not part of this PR.
* The previous hard-coded `0.5°C` temperature-step change has been removed from this PR and should be handled separately.

## 🔗 Related Issues

Fixes:
Related:

---

## ✅ Checklist

* [x] Changes tested on a real Samsung VRF system
* [x] Filter reset behavior verified successfully
* [x] Documentation/example configuration updated
* [ ] Full rebuild by maintainer / second NASA system
* [x] This PR is ready for review

---

## 🌐 Environment Information

### 🔢 Versions

* **ESPHome Version**: 2026.5.1
* **Home Assistant Version**: 2026.5.1

### 🧩 Devices

* **Air Conditioner Type**:

  * [x] NASA
  * [ ] NON-NASA
  * [ ] Other
* **System**: Samsung VRF
* **Indoor Units**: 6
* **ESP Device Model**: M5Stack Atom Lite + M5Stack Atomic RS485 Base
* **Wiring Configuration**: F1/F2
* **Outdoor Unit NASA Address**: `10.00.00`
* **Indoor Unit NASA Addresses**: `20.00.00` through `20.00.05`

---

## 🧪 Test Plan

### How were these changes tested?

1. Verified filter warning on a real Samsung indoor unit requiring filter cleaning.
2. Triggered the NASA filter reset command.
3. Verified that the Samsung filter warning cleared.
4. Verified that the corresponding Home Assistant filter warning changed from problem/ON to normal/OFF.
5. Verified that SmartThings reported the filter status as OK and updated the Last Cleaned date.

### 🔍 Example

```yaml
filter_reset:
  name: "Room Reset Filter"

custom_sensor:
  - name: "Room Filter Warning"
    message: 0x4027
    type: binary
    device_class: problem
    entity_category: diagnostic
```
