### PR TITLE
Expose compressor frequency details and Fan turbo mode for Non Nasa

### DIFF
--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -538,6 +538,8 @@ namespace esphome
             case NonNasaFanspeed::Fresh:
             case NonNasaFanspeed::High:
                 return 160;
+            case NonNasaFanspeed::Turbo:
+                return 224;
             default:
                 return 0; // Auto
             }
@@ -661,6 +663,8 @@ namespace esphome
                 return NonNasaFanspeed::Medium;
             case FanMode::Low:
                 return NonNasaFanspeed::Low;
+            case FanMode::Turbo:
+                return NonNasaFanspeed::Turbo;
             case FanMode::Auto:
             default:
                 return NonNasaFanspeed::Auto;
@@ -754,6 +758,8 @@ namespace esphome
                 return FanMode::Mid;
             case NonNasaFanspeed::Low:
                 return FanMode::Low;
+            case NonNasaFanspeed::Turbo:
+                return FanMode::Turbo;
             default:
             case NonNasaFanspeed::Auto:
                 return FanMode::Auto;

--- a/components/samsung_ac/protocol_non_nasa.cpp
+++ b/components/samsung_ac/protocol_non_nasa.cpp
@@ -970,6 +970,12 @@ namespace esphome
                     LOGW("s:%s d:%s CmdF0 outdoor_unit_error_code %d", nonpacket_.src.c_str(), nonpacket_.dst.c_str(), error_code);
                 }
                 target->set_error_code(nonpacket_.src, error_code);
+
+                target->set_custom_sensor(nonpacket_.src, 0xF005, (float)nonpacket_.commandF0.inverter_order_frequency_hz);
+                target->set_custom_sensor(nonpacket_.src, 0xF006, (float)nonpacket_.commandF0.inverter_target_frequency_hz);
+                target->set_custom_sensor(nonpacket_.src, 0xF007, (float)nonpacket_.commandF0.inverter_current_frequency_hz);
+                target->set_custom_sensor(nonpacket_.src, 0xF004, nonpacket_.commandF0.outdoor_unit_defrost_control ? 1.0f : 0.0f);
+                target->set_custom_sensor(nonpacket_.src, 0xF008, (float)nonpacket_.commandF0.outdoor_unit_bldc_fan);
             }
             else if (nonpacket_.cmd == NonNasaCommand::CmdC6)
             {

--- a/components/samsung_ac/protocol_non_nasa.h
+++ b/components/samsung_ac/protocol_non_nasa.h
@@ -16,7 +16,8 @@ namespace esphome
             Low = 2,
             Medium = 4,
             High = 5,
-            Fresh = 6
+            Fresh = 6,
+            Turbo = 7
         };
 
         enum class NonNasaMode : uint8_t


### PR DESCRIPTION
Add Inverter frequency details and fan turbo mode for non nasa air cons. Previously turbo fan mode just fell back to auto and was never set.

## 📄 Description
### What does this Pull Request do?
<!-- Provide a clear and concise description of what this PR aims to achieve. -->
- [ ] 🐞 Bug Fix
- [ X] ✨ New Feature
- [ ] 🔨 Code Improvement
- [ ] 📚 Documentation Update

### ✨ Key Changes
<!-- Briefly list the key changes or updates made in this pull request. -->
Allows compressor frequency details to be exposed as a custom sensor for non nasa device 
eg.
    - address: "c8"
      custom_sensor:
        - name: "Compressor Frequency"
          message: 0xF007
          unit_of_measurement: "Hz"
          accuracy_decimals: 0
          state_class: measurement
          icon: mdi:sine-wave
        - name: "Compressor Target Frequency"
          message: 0xF006
          unit_of_measurement: "Hz"
          accuracy_decimals: 0
          state_class: measurement
        - name: "Compressor Order Frequency"
          message: 0xF005
          unit_of_measurement: "Hz"
          accuracy_decimals: 0
          state_class: measurement
        - name: "Outdoor Fan Step"
          message: 0xF008
          accuracy_decimals: 0
          state_class: measurement
        - name: "Defrost Active"
          message: 0xF004
          type: binary


## 🔗 Related Issues
<!-- If this PR fixes or is related to any issues, mention them here. (e.g., Fixes #123 or Resolves #456) -->
Fixes: 
Related: 

---

## ✅ **Checklist**
Please ensure the following before submitting your PR:
- [ X] Code compiles without errors 🧑‍💻
- [ X] All tests pass successfully ✅
- [ X] Changes have been tested on relevant devices 🛠️
- [ ] Documentation has been updated (if necessary) 📖
- [ ] This PR is ready for review 🔍

---

## 🌐 **Environment Information**
### 🔢 Versions
- **ESPHome Version**: 
- **Home Assistant Version**: 

### 🧩 Devices
- **Air Conditioner Type**:
  - [ ] NASA
  - [ X] NON-NASA
  - [ ] Other
- **Air Conditioner Model**: AR09FSSSCWKNSA
- **Outdoor Unit Model**: (e.g., AJ050TXJ2KH/EA)
- **ESP Device Model**: M5STACK ATOM Lite
- **Wiring Configuration**: (e.g., F1/F2)

---

## 🧪 **Test Plan**
### How were these changes tested?
<!-- Describe how you tested your changes. Include details on the environment, devices used, and test cases. -->
1. Tested working on my AR09FSSSCWKNSA

### 🔍 Logs
<!-- Include relevant logs showing the changes in action, including ESPHome and Home Assistant logs. -->

---

## 🛠️ **YAML Configuration**
```yaml
# Please provide the relevant YAML configuration you used for testing this PR
```
